### PR TITLE
Add header/footer banner ads

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,10 @@
 import React, { PureComponent } from "react";
 import PageSections from "PageFactory";
 import { AppWrap, Header, Footer, Main } from "./components/general";
+import { Leaderboard } from "./components/ads";
+import { Section } from "components/primitives";
+
+import { SECTION_SPACERS, SECTION_SPACING_VARIANTS } from "constants/index";
 
 import { startAds } from "./utils/ads";
 
@@ -28,7 +32,20 @@ class App extends PureComponent<Props> {
       <AppWrap>
         <Header />
         <Main>
+          <Section>
+            <Leaderboard />
+          </Section>
+
           <PageSections data={data} />
+
+          <Section
+            style={{
+              marginTop: SECTION_SPACERS[SECTION_SPACING_VARIANTS.LARGE],
+            }}
+          >
+            <Leaderboard />
+          </Section>
+
           <Footer />
         </Main>
       </AppWrap>

--- a/src/PageFactory.js
+++ b/src/PageFactory.js
@@ -67,10 +67,10 @@ export const getSequenceAwareSpacingVariant = (
   array: Array<any>,
 ) => {
   if (index === 0) {
-    return SECTION_SPACING_VARIANTS.NONE;
+    return SECTION_SPACING_VARIANTS.SMALL;
   }
 
-  const prevSection: SectionType = array[index - 1];
+  const prevSection: SectionType = index === 0 ? null : array[index - 1];
 
   return isSmallType(currentSection) || isSmallType(prevSection)
     ? SECTION_SPACING_VARIANTS.SMALL


### PR DESCRIPTION
Updated templates to explicitly include header/footer banner ads, instead of get them dynamically